### PR TITLE
Use in memory version

### DIFF
--- a/PdfRasterizer.cs
+++ b/PdfRasterizer.cs
@@ -37,7 +37,7 @@ namespace ImageProcessor.Plugins.Pdf
 
         public Image Rasterize(string pdfUri, int pageNumber = 1)
         {
-            _rasterizer.Open(pdfUri, _lastInstalledVersion, false);
+            _rasterizer.Open(pdfUri, _lastInstalledVersion, true);
 
             var img = _rasterizer.GetPage(_desiredXDpi, _desiredYDpi, pageNumber);
 

--- a/PdfRasterizer.cs
+++ b/PdfRasterizer.cs
@@ -47,7 +47,7 @@ namespace ImageProcessor.Plugins.Pdf
 
         public Image Rasterize(Stream pdfStream, int pageNumber = 1)
         {
-            _rasterizer.Open(pdfStream, _lastInstalledVersion, false);
+            _rasterizer.Open(pdfStream, _lastInstalledVersion, true);
 
             var img = _rasterizer.GetPage(_desiredXDpi, _desiredYDpi, pageNumber);
 


### PR DESCRIPTION
I ran into some trouble using this library. The server would only render 1-3 previews per page load before just emitting `-100` error. I found a simple fix which worked as per discussed here https://github.com/jhabjan/Ghostscript.NET/issues/10.